### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/benchmark/benchmark.md
+++ b/benchmark/benchmark.md
@@ -1,5 +1,5 @@
 ### Simple benchmark 
-![benchmark](https://cdn.rawgit.com/matthieugomez/FixedEffectModels.jl/4c7d1db39377f1ee649624c909c9017f92484114/benchmark/result.svg)
+![benchmark](https://cdn.combinatronics.com/matthieugomez/FixedEffectModels.jl/4c7d1db39377f1ee649624c909c9017f92484114/benchmark/result.svg)
 
 Code to reproduce this graph:
 


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.